### PR TITLE
The MsgPack format now checks for buffer overflows during serialization ...

### DIFF
--- a/include/serialization/format/binary_format_common.h
+++ b/include/serialization/format/binary_format_common.h
@@ -1,0 +1,29 @@
+/*
+ * binary_format_common.h
+ *
+ *  Created on: Jan 16, 2015
+ *      Author: mranzinger
+ */
+
+#pragma once
+
+#include <stdexcept>
+#include <exception>
+
+#include "dll_export.h"
+
+namespace axon { namespace serialization {
+
+class CBufferOverflowException
+    : public std::exception
+{
+public:
+    virtual const char *what() const noexcept override
+    {
+        return "The specified binary operation failed because it would result in an overflow.";
+    }
+};
+
+} }
+
+


### PR DESCRIPTION
The MsgPack format now checks for buffer overflows during serialization and deserialization. A CBufferOverflowException is thrown if the buffer isn't large enough.